### PR TITLE
MOOC1 now in Swedish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+MOOC1/.DS_Store

--- a/MOOC1/README_sv.md
+++ b/MOOC1/README_sv.md
@@ -1,0 +1,28 @@
+<p align="right">
+  <a href="README.md">[EN]</a>
+  <a href="README_es.md">[ES]</a>
+  <a href="README_pt.md">[PT]</a>
+  <a href="README_tr.md">[TR]</a>
+  <a href="README_sv.md">[SV]</a>
+</p>
+
+# Lärarmanual
+
+Med fokus på lärare kommer detta avsnitt å ena sidan att vara en handledning hur verktyget används och å andra sidan en pedagogisk vägledning för dess implementering.
+
+Därför kommer det att ledas av [Karlstads Universitet](http://www.kau.se/), med tanke på dess kompetens inom pedagogik och särskilt inom e-learning. De kommer också att samarbeta med [CIFP Carlos III](https://cifpcarlos3.es/) och [Bursa MEM](http://bursa.meb.gov.tr/), som är representativa partner för yrkesutbildning och kommer att tillåta att manualen anpassas till läroplanerna för denna undervisning.
+
+Block ett kommer att bestå av följande sektioner:
+
+- [Introduktion till JuezLTI](sv/introJuezLTI.md)
+- [Hämta nycklar för JuezLTI](sv/hamtaNycklar.md)
+- [Använda JuezLTI med LMS](sv/anvandaIMoodle.md)
+- [Lärarvy](sv/lararvy.md)
+  - [Skapa en övning](sv/lararvy.md#skapa-en-uppgift)
+    - [Programmeringsövningar](sv/lararvy.md#exempeluppgift-java)
+    - [SQL-övningar](sv/lararvy.md#exempeluppgift-postgresql)
+    - XML-övningar
+  - [Importera övningar från Authorkit](sv/teacherView.md#importera-ovning-fran-authorkit)
+- [Studentvy](sv/studentVy.md)
+- [Granska resultat](sv/granskaresultat.md)
+- [Säkerhetskopiera och återställa](sv/sakerhetskopieringAterstallning.md)

--- a/MOOC1/en/teacherView.md
+++ b/MOOC1/en/teacherView.md
@@ -141,7 +141,7 @@ We don't need any input. Then, a comment is enough
 ```
 
 - **Add library**: Click on **+** button and fill with these values:
-  - title: `subjects table script`
+  - title: `countries table script`
   - body:
     ```
     CREATE TABLE countries 

--- a/MOOC1/en/usingInMoodle.md
+++ b/MOOC1/en/usingInMoodle.md
@@ -6,7 +6,7 @@ From Moodle 2.2 onwards, the **External tool** enables users to interact with LT
 
 Next, there is a summary of the [External tool](https://docs.moodle.org/400/en/External_tool) documentation in Moodle official site.
 
-Depending on your privileges in your Moodle institution site, you will be able to configure the LTI tool at activity level or at site administration level
+Depending on your privileges in your Moodle institution site, you will be able to configure the LTI tool at activity level or at site administration level.
 
 ## Activity level
 
@@ -25,7 +25,7 @@ Once you have selected the **external tool activity** ![](../docs/img/gettingCre
     - Embed without blocks - the external tool will be embedded in the Moodle course page but without blocks
     - New Window - the external tool will open in a new window. (A new window or tab will open with the External tool and the old browser window containing the course page will not change.)
 
-_The following settings are available by clicking ""Show more":_
+_The following settings are available by clicking "Show more":_
 - **Activity description** - give a short description here
 - **Display description on course page** - choose to show the description along with the activity name
 - **Display activity name when launched** - have this appear when the student clicks the link.

--- a/MOOC1/sv/anvandaIMoodle.md
+++ b/MOOC1/sv/anvandaIMoodle.md
@@ -1,0 +1,92 @@
+# Använda JuezLTI i Moodle
+
+![Juez i LMS](../docs/img/gettingCredentials/juezLTI_UsingCredentialsInLMS.png)
+
+Från Moodle 2.2 och framåt kan **Externt verktyg** göra att användare kan interagera med LTI-kompatibla lärresurser och aktiviteter på andra webbplatser. Då är valet **Externt verktyg** det rätta sättet att använda JuezLTI från Moodle.
+
+Det finns en sammanfattning av dokumentationen för [Externt verktyg](https://docs.moodle.org/400/en/External_tool) på Moodles officiella webbplats.
+
+Beroende på dina privilegier på din institutions Moodle-webbplats kommer du att kunna konfigurera LTI-verktyget på aktivitetsnivå eller på webbplatsadministrationsnivå.
+
+## Aktivitetsnivå
+
+När du har valt **externt verktygs** ![](../docs/img/gettingCredentials/externalTool2.png) eller ![](../docs/img/gettingCredentials/externalTool.png) måste du fylla i formuläret:
+
+- **Aktivitetsnamn** - lägg till en titel, beskrivning vid behov, med ditt val av visning.
+- **Förkonfigurerat verktyg** - det här är hur Moodle kommunicerar med verktygsleverantören. Om du är osäker, lämna som standard. Om din administratör har gjort ett verktyg tillgängligt på hela webbplatsen, kommer du att kunna välja det här:![Preconfiguredtool.png](https://docs.moodle.org/400/en/images_en/7/7c/Preconfiguredtool. png)
+
+- **Verktygs-URL** - Detta är URL:en för att ansluta till webbplatsen. Om din moodle-webbplats använder [SSL](https://en.wikipedia.org/wiki/Transport_Layer_Security) (använder sig av [HTTPS](https://docs.moodle.org/400/en/HTTPS)) kommer du bara att kunna använda ett verktyg som också använder [SSL](https://en.wikipedia.org/wiki/Transport_Layer_Security). Se till att verktygets URL har [HTTPS](https://docs.moodle.org/400/en/HTTPS) innan du försöker använda det, annars kan du få en tom sida.
+
+    I betaversionen av JuezLTI måste webbadressen fyllas med [https://beta.juezlti.eu/tsugi/mod/codetest/](https://beta.juezlti.eu/tsugi/mod/codetest/). _Glöm inte att avsluta med "/"_.
+
+- **Öppna container** - det här är hur det externa verktyget kommer att visas.
+    - Standard - om du är osäker; lämna som standard
+    - Bädda in - det externa verktyget kommer att bäddas in i Moodles kurssida med block och navigeringsfält
+    - Bädda in utan block - det externa verktyget kommer att bäddas in på Moodle-kurssidan men utan block
+    - Nytt fönster - det externa verktyget öppnas i ett nytt fönster. (Ett nytt fönster eller flik öppnas med det externa verktyget och det gamla webbläsarfönstret som innehåller kurssidan kommer inte att ändras.)
+
+_Följande inställningar är tillgängliga genom att klicka på "Visa mer":_
+- **Aktivitetsbeskrivning** - ge en kort beskrivning här
+- **Visa beskrivning på kurssidan** - välj att visa beskrivningen tillsammans med aktivitetens namn
+- **Visa aktivitetens namn när den startas** - visas när studenten klickar på länken.
+- **Visa aktivitetsbeskrivning när den startas** - visas när studenten klickar på länken.
+- **Secure tool URL** - Detta åsidosätter verktygets URL när Moodle använder [SSL](https://en.wikipedia.org/wiki/Transport_Layer_Security) (om din webbplats är konfigurerad att använda [HTTPS](https:/ /docs.moodle.org/400/en/HTTPS))
+- **<u>Konsumentnyckel</u>** - här måste du klistra in [**nyckeln** från JuezLTI](hamtaAutentisering.md).
+- **<u>Delad hemlighet</u>** - och här, **hemligheten**.
+- **Anpassade parametrar** - normalt kan du lämna detta tomt. Verktygsleverantören kan använda detta för att låta dig visa en specifik resurs.
+- **URL ikon** - du kan visa en annan ikon än standardikonen för det externa verktyget genom att ange dess URL här
+- **Secure Icon URL** - ange webbadressen till en annan ikon här om dina studenter använder Moodle säkert via [SSL](https://en.wikipedia.org/wiki/Transport_Layer_Security).
+
+## Integritet
+
+- **Dela startprogrammets namn med verktyget** - detta betyder att studentens namn kommer att visas på den anslutna webbplatsen [som i det här exemplet](https://docs.moodle.org/400/en/images_en/1/ 13/demoexternaltool.png)
+- **Dela startprogrammets e-post med verktyget** - detta betyder att elevens e-post kommer att visas på den anslutna webbplatsen [som i detta exempel](https://docs.moodle.org/400/en/images_en/2/ 27/externaltoolfrontpage.png)
+- **Acceptera betyg från verktyget** - om detta är markerat kommer den anslutande sidan att skicka tillbaka betyg till Moodles betygsbok. Se [Använda externt verktyg](https://docs.moodle.org/400/en/Using_External_tool) för mer information om detta.
+
+## Inställningar för webbplatsadministration
+
+### Lägga till ett verktyg för hela webbplatsen
+
+En administratör kan manuellt konfigurera externa verktyg i _Webbplatsadministration > Plugins > Aktivitetsmoduler > Externt verktyg > Hantera verktyg_ så att de är tillgängliga på hela webbplatsen.
+
+![Lägga till ett externt verktyg](https://docs.moodle.org/400/en/images_en/thumb/e/e2/moodle310_external_tool_registration.png/450px-moodle310_external_tool_registration.png)
+
+Ett verktyg kan konfigureras av en administratör så att det visas i aktivitetsväljaren (utöver den externa verktygsaktiviteten) så att en lärare kan välja att lägga till i en kurs. Dess beskrivning, om en sådan finns, visas i aktivitetsväljaren.
+
+### Visa mer information
+
+På sidan _"Hantera verktyg"_  kan du också besöka _"Hantera förkonfigurerade verktyg"_ för att se de förkonfigurerade verktygen i ett tabellformat.
+
+Det finns flikar för att lägga till ett externt verktyg, för att se de som väntar och för att se de som har avvisats:
+![Konfigurera ett nytt externt verktyg](https://docs.moodle.org/400/en/images_en/thumb/4/43/LTItype.png/450px-LTItype.png)
+
+Du kan också besöka _"Hantera externa verktygsregistreringar"_ för att se verktygsregistreringarna i tabellformat eller för att lägga till en extern registrering med begränsad kapacitet.
+
+För att lägga till ett verktyg med begränsad kapacitet.
+1. Klicka på "Konfigurera en ny extern verktygsregistrering"
+
+![Registrera ett externt verktyg](https://docs.moodle.org/400/en/images_en/thumb/d/d9/LTIreg.png/450px-LTIreg.png)
+
+2. Konfigurera detaljerna på inställningssidan:
+
+![Sidan för registreringsinställningar](https://docs.moodle.org/400/en/images_en/thumb/8/8f/LTIregdetails1.png/450px-LTIregdetails1.png)
+
+_'Medlemskap'_, låter det externa verktyget begära en lista över användare med en viss roll i ett specifikt sammanhang t.ex. användare som är anmälda till en kurs.
+
+3. Klicka på bocken för att registrera:
+
+![Aktivera](https://docs.moodle.org/400/en/images_en/thumb/3/3a/ticktoreg.png/450px-ticktoreg.png)
+
+4. När du har fått ett meddelande om att registreringen fungerat klickar du för att slutföra processen:
+
+![Slutför registreringen](https://docs.moodle.org/400/en/images_en/thumb/0/05/reqmet.png/300px-reqmet.png)
+
+5. Om alla krav är uppfyllda kommer du att kunna registrera dig automatiskt.
+
+6. Gå nu till _Webbplatsadministration > Plugins > Aktivitetsmoduler > Externt verktyg > Hantera externa verktygstyper_ och klicka på fliken "Väntande"
+
+7. Klicka på bocken för att aktivera den:
+
+![Aktiverar från fliken Väntar](https://docs.moodle.org/400/en/images_en/thumb/6/68/pendingactivate.png/450px-pendingactivate.png)
+
+Se screencasten [Extern verktygsregistrering](http://www.spvsoftwareproducts.com/temp/lti2-moodle/) för en demonstration av stegen ovan.

--- a/MOOC1/sv/granskaResultat.md
+++ b/MOOC1/sv/granskaResultat.md
@@ -1,0 +1,39 @@
+# Reviewing results
+
+Instructors have two places where they could review the results of students:
+
+  - [Reviewing results in Teacher View](#reviewing-results-in-teacher-view)
+  - [Reviewing results in Grade LMS](#reviewing-results-in-grade-lms)
+
+
+## Reviewing results in Teacher View
+
+Instructors can follow the activity of their students in the menu _Results_.
+
+Below, the list of exercises solved by _Student JuezLTI_ is showed:
+
+![Review Results in Results Menu of JuezLTI](../docs/img/reviewResults/reviewResultsGradeJuezResults.png)
+
+As you can see, that student has solved only one of the three exercises proposed in the activity and clicking on _SHOW CODE_ button the instructor could see his answers.
+
+Then, in _Grade_ menu instructor could view the grade obtained by the student.
+
+The image below shows how 33.33% is the grade obtained by _Student JuezLTI_ in the activity.
+
+![Review Results in Grade Menu of JuezLTI](../docs/img/reviewResults/reviewResultsGradeJuezGrade.png)
+
+JuezLTI allows the instructors to modify the grade of any student, changing the value in the text box and clicking on _Update_ button.
+
+## Reviewing results in Grade LMS
+
+Remember that the grade obtained on JuezLTI is sent to LMS using LTI standard. So, the same grade that the instructor could see in JuezLTI could also be seen in LMS.
+
+![Reviewing Results in LMS](../docs/img/reviewResults/reviewResultsGradeLMS.png)
+
+In the real scenario below, the instructor allows the students to go forward in different speeds and he could see where the students find more difficulties and who needs more help.
+
+![Reviewing Result in a Real Scenario](../docs/img/reviewResults/reviewResultsRealGrade.png)
+
+## Download results
+
+A spreadsheet with students' results is also available for downloading.

--- a/MOOC1/sv/hamtaNycklar.md
+++ b/MOOC1/sv/hamtaNycklar.md
@@ -1,0 +1,53 @@
+# Hämta nycklar
+För att säkra meddelandeinteraktioner mellan LMS och JuezLTI används OAuth-protokollet. OAuth-signering kräver en **nyckel** och delad **hemlighet** för att signera meddelanden. Nyckeln sänds med varje meddelande, såväl som en OAuth-genererad signatur som är baserad på nyckeln. JuezLTI letar upp hemligheten baserat på den tillhandahållna nyckeln och beräknar en egen signatur. Om den beräknade signaturen och den överförda jämförs för att verifiera avsändaren.
+
+Proceduren för att få nyckeln och hemligheten inkluderar:
+- [Hämta nycklar](#hamta-nycklar)
+  - [JuezLTI-autentisering](#juezlti-autentisering)
+  - [Begäran av nyckel/hemlighet](#begaran-av-nyckelhamlighet)
+  - [Authorization by JuezLTI admin](#autentisering-av-juezlti-admin)
+  - [Nyckel/hemlighet skickad](#nyckelhemlighet-skickad)
+
+Dessa steg visas i bilden nedan:
+![Hämta nycklar](../docs/img/gettingCredentials/juezLTI_gettingCredentials.jpg)
+
+## JuezLTI-autentisering
+
+JuezLTI använder [Tsugi](https://www.tsugi.org) för att hantera nyckel-/hemliga förfrågningar och Tsugi kräver autentisering med ditt Google-konto. Gå sedan till [JuezLTI Tsugi-sida](https://beta.juezlti.eu/tsugi/) och klicka på Logga in som bilderna nedan visar:
+![Tsugi inloggning](../docs/img/gettingCredentials/loginTsugi.png)
+![Välj Google-konto](../docs/img/gettingCredentials/googleLogin.png)
+
+Det valda Google-kontot kommer att få nyckel-/hemlighetsuppgifterna.
+
+Efter autentisering via Google kommer en profilsida att visas och du kommer att kunna välja dina profilinställningar och spara dem genom att klicka på knappen **Spara** eller **Spara profil**:
+![Välj profilinställningar](../docs/img/gettingCredentials/profile.png)
+
+## Begäran av nyckel/hemlighet
+
+När du är autentiserad klickar du på Inställningar
+![Åtkomst via inställningar](../docs/img/gettingCredentials/settings.png)
+
+Om detta är din första begäran kommer du att se en (0) nära **Hantera LMS-åtkomstnycklar**. Klicka på **Hantera LMS-åtkomstnycklar**
+![Hantera LMS-åtkomstnycklar](../docs/img/gettingCredentials/LMS_Access_keys_0.png)
+Knappen LTI-nycklar markeras och meddelandet _"Du har inga IMS LTI-nycklar för detta system."_ visas under.
+
+Klicka på knappen **Nyckelbegäran**
+![Klicka på knappen Nyckelbegäran](../docs/img/gettingCredentials/keyRequestButton.png)
+
+Och sedan, på **ny nyckelbegäran**
+![Klicka på knappen Ny nyckelbegäran](../docs/img/gettingCredentials/newKeyRequest.png)
+
+Fyll i formuläret och förklara varför eller var du ska använda nycklarna.
+![Fyll i formuläret](../docs/img/gettingCredentials/explainWhy.png)
+
+En ny nyckel med status (**Väntar**) har begärts.
+![Nyckel väntar skapad](../docs/img/gettingCredentials/keyWaiting.png)
+
+## Autentisering av JuezLTI admin
+
+Ett e-postmeddelande skickas till personalen på JuezLTI och din nyckelbegäran kommer att godkännas så snart som möjligt. I det ögonblicket kommer du att få ett e-postmeddelande med bekräftelsen till ditt Google-konto.
+
+## Nyckel/hemlighet skickad
+
+När du får bekräftelsen på godkännande till din e-post kommer du att kunna logga in igen och den godkända nyckeln kommer att visas i avsnittet **LTI Keys**.
+![Nyckel godkänd](../docs/img/gettingCredentials/keyApproved.png)

--- a/MOOC1/sv/introJuezLTI.md
+++ b/MOOC1/sv/introJuezLTI.md
@@ -1,0 +1,5 @@
+# Vad är JuezLTI?
+[JuezLTI](https://juezlti.eu) är ett verktyg som tillåter **automatisk bedömning av datorstudieövningar**, nämligen märkspråk samt programmerings- och databasövningar. Verktyget är också innovativt på grund av dess **kompatibilitet med alla lärplattformar (LMS) som Moodle, Sakai, Canvas eller Blackboard** (med flera) tack vare användningen av LTI-standarden. Detta, tillsammans med biblioteket med övningar som utvecklats i projektet, gör att det kan användas på ett stort antal institutioner, av vilka några har visat intresse och uttryckligt stöd för projektet.
+
+Bilden nedan visar användningsdiagrammet för JuezLTI:
+![JuezLTI: Användningsdiagram](../docs/img/introJuezLTI/juezLTI_UsageDiagram.png)

--- a/MOOC1/sv/lararvy.md
+++ b/MOOC1/sv/lararvy.md
@@ -1,0 +1,186 @@
+# Lärarvy
+
+![Diagram lärarvy](../docs/img/teacherView/teacherViewUsageDiagram.png)
+
+När du skapat ett **externt verktyg** ![](../docs/img/gettingCredentials/externalTool2.png) eller ![](../docs/img/gettingCredentials/externalTool.png) och visar det, kommer du att se en välkomstsida:
+
+![Get Started Page](../docs/img/teacherView/getStartedPage.png)
+
+Klicka då bara på **Get Started** knappen
+
+Då kommer du att se lärarens kontrollcenter:
+![Teacher Control Center](../docs/img/teacherView/teacherViewControlCenter.png)
+
+När du startar kommer varje räknare att vara **0**:
+- uppgifter
+- användning
+- betyg 
+
+## Skapa en uppgift
+
+Efterson JuezLTI använder sig av [_YAPExIL_](https://raw.githubusercontent.com/FGPE-Erasmus/format-specifications/master/schemas/yapexil.schema.json) formatet för att spara alla uppgiftstyper så är gränssnittet samma vare sig du skapar en uppgift för programmering, databaser eller ett märkspråk.
+
+Bilden nedan visar formuläret för at skapa en uppgift:
+![Create Exercise Form](../docs/img/teacherView/teacherViewCreateExerciseForm.png)
+
+## Exempel
+Exemplen nedan visar hur du fyller i formuläret för CodeTest för att få en Java- eller PostgreSQLuppgift.
+
+För uppgifter som kräver mer egenskaper från YAPExIL rekommenderar JuezLTI [Authorkit](https://python.usz.edu.pl/authorkit/ui/dashboard). 
+### Exempelövning Java:
+- **Uppgiftens titel**: `Welcome`
+- **Nyckelord**: `Input, Output`
+- **Uppgiftsbeskrivning**: Skriv ett Java-program som skriver ut "Hej" följt av ett namn som ska läsas in via standard input.
+
+- **Kodlösning**: 
+```
+import java.util.Scanner;
+
+public class Main {
+
+    public static void main(String[] args)
+    {
+        Scanner input = new Scanner (System.in);
+        String name = input.next();
+        System.out.print("Hello "+name);
+    }
+}
+```
+
+- **Språk**: Java
+
+- **Med dessa indata**: "Charles"
+
+- **Förväntas dessa utdata**: "Hej Charles"
+
+- **Addera bibliotek**: _För närvarande används detta bara för att kunna använda test data för att **testa databasuppgifter**_.
+
+Klicka på knappen **Spara uppgift** för att komma till uppgiftslistan. Från den sidan kan du välja att redigera eller ta bort uppgifter som du skapat med CodeTest.
+
+### Exempeluppgift PostgreSQL:
+
+JuezLTI tillåter dig att skapa uppgifter av typen DQL, DDL och DML. Nedan följer ett exempel på att skapa en DDL-uppgift:
+- **Uppgiftens titel**: "ALTER TABLE: RENAME"
+- **Nyckelord**: `DDL, RENAME TABLE`
+- **Uppgiftbeskrivning**: 
+```
+Tänk dig att vi har skapat följande tabell:
+    CREATE TABLE SUBJECTS (
+        Name VARCHAR(100),
+        NumHours INTEGER
+    );
+Byt namn på tabellen SUBJECTS till MODULES.
+```
+
+- **Code solution**: 
+```
+ALTER TABLE SUBJECTS RENAME TO MODULES;
+```
+
+- **Språk**: PostgreSQL
+
+- **Med dessa indata**: 
+```
+SELECT table_name, column_name, data_type
+FROM information_schema.columns
+WHERE lower(table_name) in ('modules', 'subjects') and table_schema = 'public'
+ORDER BY column_name;
+```
+
+- **Förväntas dessa utdata**:
+```
+ table_name | column_name |     data_type     
+------------+-------------+-------------------
+ modules    | name        | character varying
+ modules    | numhours    | integer
+(2 rows)
+```
+
+- **Addera bibliotek**: Klicka på knappen **+** och fyll i dessa värden:
+  - titel: "uppgiftens tabellskript"
+  - innehåll:
+    ```
+    CREATE TABLE SUBJECTS (
+        Name VARCHAR(100),
+        NumHours INTEGER
+    );
+    ```
+
+Klicka på knappen **Spara uppgift** för att komma till uppgiftslistan. Från den sidan kan du välja att redigera eller ta bort uppgifter som du skapat med CodeTest.
+
+![Sidan med uppgifter](../docs/img/teacherView/exercisesList.png)
+Nedan följer ett exempel på en DQL-uppgift:
+- **Uppgiftens titel**: `Unconditional SELECT`
+- **Nyckelord**: `DQL, Unconditional`
+- **Uppgiftsbeskrivning**: 
+```
+Visa alla data som finns sparat i tabellen countries.
+```
+- **Kodlösning**: 
+```
+SELECT * FROM countries
+```
+
+- **Språk**: PostgreSQL
+
+- **Med dessa indata**:
+Vi behöver inga input så en kommentar är tillräckligt
+```
+-- .
+```
+
+- **Förväntas följande utdata**:
+```
+ country_id | country_name | region_id 
+------------+--------------+-----------
+ ES         | Spain        | 1
+ PT         | Portugal     | 1
+ SE         | Sweden       | 1
+ TR         | Türkiye      | 1
+(4 rows)
+```
+
+- **Addera bibliotek**: Klicka på knappen **+** fyll i följande värden:
+  - Titel: `countries tabelskript`
+  - Innehåll:
+    ```
+    CREATE TABLE countries 
+        ( country_id CHAR(2) not null PRIMARY KEY       
+        , country_name VARCHAR(40) 
+        , region_id INTEGER REFERENCES regions(region_id)
+        ); 
+
+    INSERT INTO countries VALUES( 'ES', 'Spain', 1);
+    INSERT INTO countries VALUES( 'PT', 'Portugal', 1);
+    INSERT INTO countries VALUES( 'SE', 'Sweden', 1);
+    INSERT INTO countries VALUES( 'TR', 'Türkiye', 1);
+    ```
+
+Klicka på knappen **Spara uppgift** för att komma till uppgiftslistan. Från den sidan kan du välja att redigera eller ta bort uppgifter som du skapat med CodeTest.
+
+## Importera uppgifter från Authorkit
+
+JuezLTI-teamet har delat olika grupper av uppgifter i [Authorkit](https://python.usz.edu.pl/authorkit/ui/dashboard) för att kunna låta lärare använda JuezLTI med så liten ansträngning som möjligt:
+- [101 Java-uppgifter](https://python.usz.edu.pl/authorkit/ui/projects/7f1dc980-a4ed-4c94-9488-e3db1f36c7e1/exercises)
+- PostgreSQL exercises
+  - [58 DQL-uppgifter](https://python.usz.edu.pl/authorkit/ui/projects/3b71a2f0-e295-4a95-988d-bd6aa9b73ca8/exercises)
+  - [22 DDL-uppgifter](https://python.usz.edu.pl/authorkit/ui/projects/4f0281e5-2543-49a9-b0e5-83324553a579/exercises)
+  - [16 DML-uppgifter](https://python.usz.edu.pl/authorkit/ui/projects/83a38e8c-e4c4-45d3-b1a6-ec7509c433d5/exercises)
+
+Varje AuthorKit-uppgift kan importeras till JuezLTI genom att välja _Importera från AuthorKit_ i menyn eller panelen _Uppgfiter_.
+
+När _Importera från Authorkit_ väljs visas ett fönstersom visar vilka grupper av uppgifter som är publika.
+
+JuezLTI rekommenderar att börja med grupperna med uppgifter som redan har testats:
+- JuezLTI Programming
+- MOOC exercises DB: DQL
+- MOOC exercises DB: DDL
+- MOOC exercises DB: DML
+
+Klicka på önskad grupp och välj sedan den uppgift som du vill importera.
+![Rekommenderade grupper med uppgifter](../docs/img/teacherView/exercisesGroupsRecommended.png)
+![Uppgift att importera markerad](../docs/img/teacherView/exerciseSelected.png)
+
+Genom _Uppgiftslistan_ kan du se att uppgifterna blivit importerade. Uppgifter importerae från AuthorKit går inte att redigera.
+![Uppgiftslistan efter import](../docs/img/teacherView/exercisesListAfterImport.png)
+

--- a/MOOC1/sv/sakerhertskopieringAterstallning.md
+++ b/MOOC1/sv/sakerhertskopieringAterstallning.md
@@ -1,0 +1,18 @@
+# Säkerhetskopiering och återställning
+
+Instruktörer kan exportera (aktiviteten) med övningarna den är sammansatt av för att importera den till en annan aktivitet eller LMS.
+
+Stegen för att göra det skulle vara följande:
+
+1. Exportera till en zip-fil genom att välja alternativet som visas i bilden nedan.
+
+![Exportera till en zip-fil](../docs/img/backupRestore/exportZipFile.png)
+
+2. Skapa en ny aktivitet i LMS som den förklaras i kapitlet _[Använda i Moodle](anvandaIMoodle.md)_.
+3. Öppna aktiviteten och få tillgång till _Lärarvy_
+4. Importera zip-filen som tidigare laddats ner.
+![Importera zip-fil](../docs/img/backupRestore/importZipFile.png)
+5. Bekräfta importen.
+![Bekräfta importen](../docs/img/backupRestore/importConfirmation.png)
+
+Till slut ser du hur antalet övningar har förändrats och ökat till antalet övningar som hör till den ursprungliga filen.

--- a/MOOC1/sv/studentvy.md
+++ b/MOOC1/sv/studentvy.md
@@ -1,0 +1,76 @@
+# Studentvy
+
+![Diagram studentvy](../docs/img/studentView/studentViewUsageDiagram.png)
+
+När instruktörerna har skapat ett **externt verktyg** ![](../docs/img/gettingCredentials/externalTool2.png) eller ![](../docs/img/gettingCredentials/externalTool.png) kan studenterna se det på sin kurssida:
+
+![Välj extern aktivitet](../docs/img/studentView/selectingExternalActivity.png)
+
+Studenten behöver bara klicka på den externa aktiviteten. I det här fallet, _Lätta uppgifter_
+
+En studentvy som liknar bilden nedan visas:
+![Sida för studentformulär](../docs/img/studentView/studentViewFormPage.png)
+
+Överst på sidan visas listan över uppgifter som ingår i aktiviteten:
+
+![Studentvy lista uppgifter](../docs/img/studentView/studentViewListExercises.png)
+
+Exemplet ovan visar en aktivitet som består av tre övningar, i ett av de tre möjliga tillstånden vardera:
+
+- _orange_: studenten svarade inte på övningen.
+- _grön_: studenten löste övningen.
+- _röd_: studenten gav ett felaktigt svar på övningen.
+
+Studenten kan använda listan med övningar för att navigera genom övningarna, benom att klicka på dem.
+
+Efter övningslistan återfinns övningens titel och beskrivning
+
+![Studentvy titel och beskrivning](../docs/img/studentView/studentViewTitleStatement.png)
+
+och grupper av uppgifter
+
+![SStudentvy testgrupper](../docs/img/studentView/studentViewTests.png)
+
+I de uppgifterna kan studenten se utdata som motsvarar varje indata. I exemplet ovan, om koden tar emot "Charles", måste den returnera "Hello Charles".
+
+Studenten ska skriva sin kodlösning i fältet _Kodlösning_ och sedan välja på vilket språk lösningen ska kodas:
+
+![Studentvy svar](../docs/img/studentView/studentViewAnswer.png)
+
+Längst ner på sidan får studenten betyget och feedback på sitt svar.
+
+Ovan kan du se resultatet av två olika koder:
+
+- Fel svar:
+
+```
+import java.util.Scanner;
+
+public class Main {
+
+    public static void main(String[] args)
+    {
+        Scanner input = new Scanner (System.in);
+        String name = input.next();
+        System.out.print("Hello "+name+"!!");
+    }
+}
+```
+![Studentvy fel svar](../docs/img/studentView/studentViewWrongAnswer.png)
+
+- Rätt svar:
+
+```
+import java.util.Scanner;
+
+public class Main {
+
+    public static void main(String[] args)
+    {
+        Scanner input = new Scanner (System.in);
+        String name = input.next();
+        System.out.print("Hello "+name);
+    }
+}
+```
+![Studentvy rätt svar](../docs/img/studentView/studentViewRightAnswer.png)

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ This second intellectual product therefore proposes the development of the docum
 As leaders, the [Karlstad Uni](http://www.kau.se/) will be in charge of the pedagogical design of the MOOC, as well as the style and format guides that the materials to be developed must follow. Likewise, they will control the unanimous development of the tasks assigned to each partner.
 
 The MOOC will have three differentiated blocks, each of which will be developed by one of the partners, based on their knowledge and participation in the project.
-The language in which the materials will be developed will be English, so all partners will collaborate in the translation tasks into their native language: Swedish, Turkish, [Portuguese](README_pt.md) and [Spanish](README_es.md).
+The language in which the materials will be developed will be English, so all partners will collaborate in the translation tasks into their native language: [Swedish](README_sv.md), Turkish, [Portuguese](README_pt.md) and [Spanish](README_es.md).

--- a/README_sv.md
+++ b/README_sv.md
@@ -1,0 +1,24 @@
+<p align="right">
+  <a href="README.md">[EN]</a>
+  <a href="README_es.md">[ES]</a>
+  <a href="README_pt.md">[PT]</a>
+  <a href="README_tr.md">[TR]</a>
+  <a href="README_sv.md">[SV]</a>
+</p>
+
+# IO2: Dokumentation och MOOC för JuezLTI
+En öppen onlinekurs utvecklas och lärs ut för att utbilda lärare i alla aspekter relaterade till JuezLTI:
+- Grunderna i JuezLTI.
+- Implementering på institutionens servrar.
+- Användning av det gemensamma frågearkivet.
+- Koppla ihop med institutionens LMS
+- Utveckling av frågeformulär och frågor.
+- Export och import.
+- Exempel på träningsvägar
+
+Denna andra intellektuella produkt föreslår därför utvecklingen av dokumentationen för JuezLTI-applikationen: [lärarmanual](MOOC1/README_sv.md#larar-manual), [deployment manual](MOOC2/README_sv.md#deployment-manual) och [ utvecklingsmanual](MOOC2/README_sv.md#utvecklingsmanual). Baserat på dessa material kommer en onlinekurs att byggas som ett "Massive Open Online Courses" (MOOC).
+
+[Karlstads Universitet](http://www.kau.se/) kommer att ansvara för den pedagogiska utformningen av MOOC, samt de stil- och formatguider som materialet som det utvecklade materialet bör följa. På samma sätt kommer de att kontrollera utvecklingen av de uppgifter som tilldelats varje partner.
+
+MOOC kommer att ha tre differentierade block, som vart och ett kommer att utvecklas av en av partnerna, baserat på deras kunskap och deltagande i projektet.
+Språket som materialet kommer att utvecklas på kommer att vara engelska, så alla partners kommer att samarbeta i översättningsuppgifterna till sitt modersmål: [svenska](README_sv.md), turkiska, [portugisiska](README_pt.md) och [spanska](README_es.md).


### PR DESCRIPTION
I have translated MOOC1  to Swedish and updated the English readme-files to link to the Swedish files. I also corrected a title for a table script in the English version as it said the table script was about countries I thought that the title should reflect this. Also updated som minor typos in another English file.